### PR TITLE
Add Gakuto Kita (2511085, PitaPitaPiPiPi) to Contributors.md and SE-c…

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -657,3 +657,4 @@ L200194209 - Fadhlih Hasan Setiawan <br/>
 2511180 - Masaru Tanibata <br/>
 2511246 - Suzuka Higashitsutsumi (id:suzuka215) </br>
 2511343 - TANUSA yanisa - emmyyanisa <br/>
+2511085 - Gakuto Kita (id: PitaPitaPiPiPi) <br/>

--- a/SE-class-2025
+++ b/SE-class-2025
@@ -71,3 +71,4 @@
 2511210 - Nakano Atsushi </br>
 2511246 - Suzuka Higashitsutsumi (id:suzuka215) </br>
 2511343 - TANUSA Yanisa - emmyyanisa </br>
+2511085 - Gakuto Kita (id: PitaPitaPiPiPi) <br/>


### PR DESCRIPTION
Name: Gakuto Kita
Student ID：2511085
GitHub ID：  PitaPitaPiPiPi
を Contributors.md および SE-class-2025 に追加しました。